### PR TITLE
Script brukt i credits scenen

### DIFF
--- a/scripts/credits_scene.gd
+++ b/scripts/credits_scene.gd
@@ -1,0 +1,5 @@
+extends Control
+
+func _input(event):
+	if Input.is_action_pressed("cancel"):
+		visible = false


### PR DESCRIPTION
Dette skriptet brukes nå til å kanselere credits scenen ved å gjøre den usynlig for spilleren noe som vil sende dem tilbake til hovedmenyen. 
Den vil trenge en ny input fra input map: "Cancel" som er koblet til escape knappen. Dette er så klart en midlertidig løsning, jeg innser at jeg må sette den til en 'touch' knapp på ett tidspunkt