### PR TITLE
Skript  brukt for credits scenen

### DIFF
--- a/scripts/credits_scene.gd
+++ b/scripts/credits_scene.gd
@@ -1,0 +1,5 @@
+extends Control
+
+func _on_button_pressed():
+	visible = false
+	pass # Replace with function body.


### PR DESCRIPTION
Dette skriptet brukes nå til å kanselere credits scenen ved å gjøre den usynlig for spilleren noe som vil sende dem tilbake til hovedmenyen.