### PR TITLE
implementert bakgrunn og fikset credits

### DIFF
--- a/scenes/canvas_layer/canvaslayer_skog.tscn
+++ b/scenes/canvas_layer/canvaslayer_skog.tscn
@@ -16,34 +16,34 @@ offset = Vector2(1000, 1199.9)
 
 [node name="Far parallax" type="ParallaxLayer" parent="ParallaxBackground"]
 z_index = 3
-position = Vector2(-224, 606)
+position = Vector2(-224, -100)
 motion_scale = Vector2(0.25, 0.25)
 motion_offset = Vector2(1, 0)
 motion_mirroring = Vector2(1836, 1600)
 
 [node name="Far paralax" type="Sprite2D" parent="ParallaxBackground/Far parallax"]
-position = Vector2(785, -114)
+position = Vector2(785, 0)
 texture = ExtResource("2_w3ah7")
-offset = Vector2(14.2468, -135.61)
+offset = Vector2(14.247, 0)
 
 [node name="Middle parallax" type="ParallaxLayer" parent="ParallaxBackground"]
 z_index = 4
-position = Vector2(763, 683)
+position = Vector2(763, -100)
 motion_scale = Vector2(0.5, 0.5)
 motion_mirroring = Vector2(1836, 0)
 
 [node name="Middle paralax" type="Sprite2D" parent="ParallaxBackground/Middle parallax"]
 z_index = 3
-position = Vector2(831, -288)
+position = Vector2(831, 0)
 texture = ExtResource("3_bb0gd")
 
 [node name="Close parallax" type="ParallaxLayer" parent="ParallaxBackground"]
 z_index = 5
-position = Vector2(0, 393)
+position = Vector2(0, -100)
 motion_scale = Vector2(0.8, 0.8)
 motion_mirroring = Vector2(1836, 0)
 
 [node name="Close paralax" type="Sprite2D" parent="ParallaxBackground/Close parallax"]
 z_index = 4
-position = Vector2(898, 18)
+position = Vector2(898, 0)
 texture = ExtResource("4_fbu6n")

--- a/scenes/credits_scene.tscn
+++ b/scenes/credits_scene.tscn
@@ -1,14 +1,27 @@
-[gd_scene load_steps=2 format=3 uid="uid://bgkfbxvfcxyg8"]
+[gd_scene load_steps=4 format=3 uid="uid://bgkfbxvfcxyg8"]
+
+[ext_resource type="Script" path="res://scripts/credits_scene.gd" id="1_3uh8h"]
+[ext_resource type="FontFile" uid="uid://i6a6arv6m8b3" path="res://assets/fonts/AR_One_Sans/AROneSans-VariableFont_ARRR,wght.ttf" id="2_bmvhq"]
 
 [sub_resource type="Theme" id="Theme_5ysfw"]
 
-[node name="Control" type="Control"]
+[node name="credits" type="Control"]
 layout_mode = 3
 anchor_left = 0.000844552
 anchor_right = 1.00084
 anchor_bottom = 1.0
 offset_left = 0.743206
 offset_right = 0.752075
+script = ExtResource("1_3uh8h")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
 
 [node name="Sound effect" type="TextEdit" parent="."]
 visible = false
@@ -54,6 +67,7 @@ offset_left = -2.0
 offset_right = 1521.2
 offset_bottom = 720.0
 theme = SubResource("Theme_5ysfw")
+theme_override_fonts/font = ExtResource("2_bmvhq")
 text = "Author,  Animator,  Artist  and  programmer:
 
 LONGJUMPPRODUCTION
@@ -63,17 +77,19 @@ Music:
 SYNTRUS (on newgrounds)"
 editable = false
 
-[node name="ReturnBox" type="TextEdit" parent="."]
+[node name="Button" type="Button" parent="."]
 layout_mode = 1
 anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-offset_left = -320.0
-offset_top = -140.0
-offset_right = 320.0
+offset_left = -318.001
+offset_top = -148.0
+offset_right = 332.999
 grow_horizontal = 2
 grow_vertical = 0
-text = "PRESS ESCAPE TO RETURN TO THE PREVIOUS SCREEN"
-editable = false
+theme_override_fonts/font = ExtResource("2_bmvhq")
+text = "LUKK"
+
+[connection signal="pressed" from="Button" to="." method="_on_button_pressed"]

--- a/scenes/menu.tscn
+++ b/scenes/menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://blc5mfiw70f2"]
+[gd_scene load_steps=13 format=3 uid="uid://blc5mfiw70f2"]
 
 [ext_resource type="Script" path="res://scripts/menu.gd" id="1_50igi"]
 [ext_resource type="Texture2D" uid="uid://bx2bed8b533un" path="res://assets/art_assets/many_skisse.png" id="2_qdi1i"]
@@ -11,6 +11,7 @@
 [ext_resource type="Texture2D" uid="uid://dxtujsfa36ldb" path="res://assets/art_assets/Skilt/ui_knapp_skilt_tekstur02.png" id="7_8h06r"]
 [ext_resource type="Texture2D" uid="uid://dxckx2032et1r" path="res://assets/art_assets/Skilt/ui_knapp_skilt_tekstur06.png" id="8_4n42n"]
 [ext_resource type="Texture2D" uid="uid://mhwlnf6xpllk" path="res://assets/art_assets/Skilt/ui_knapp_skilt_tekstur07.png" id="9_vas1l"]
+[ext_resource type="PackedScene" uid="uid://bgkfbxvfcxyg8" path="res://scenes/credits_scene.tscn" id="12_73gh4"]
 
 [node name="Menu" type="Node"]
 script = ExtResource("1_50igi")
@@ -261,6 +262,9 @@ text = "Pause-test"
 [node name="GameStateManager" parent="." instance=ExtResource("3_vs73n")]
 
 [node name="LevelData" parent="." instance=ExtResource("4_ujgb6")]
+
+[node name="credits" parent="." instance=ExtResource("12_73gh4")]
+visible = false
 
 [connection signal="pressed" from="Background/StartSign/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="Background/SettingsSign/SettingsButton" to="." method="_on_settings_button_pressed"]

--- a/scenes/test_level.tscn
+++ b/scenes/test_level.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=14 format=3 uid="uid://bvb1triln2bkr"]
+[gd_scene load_steps=15 format=3 uid="uid://bvb1triln2bkr"]
 
 [ext_resource type="Script" path="res://scripts/test_level.gd" id="1_x5js2"]
 [ext_resource type="PackedScene" uid="uid://1ehcmr0xs6rd" path="res://scenes/test_level/death_pit.tscn" id="2_5pbnu"]
+[ext_resource type="PackedScene" uid="uid://bp0wo13r77st6" path="res://scenes/canvas_layer/canvaslayer_skog.tscn" id="2_bmjn4"]
 [ext_resource type="Script" path="res://scripts/health.gd" id="2_pktii"]
 [ext_resource type="PackedScene" uid="uid://jp5qnjxxce37" path="res://scenes/obstacles/boar.tscn" id="3_jdk35"]
 [ext_resource type="PackedScene" uid="uid://b003u3f21kj54" path="res://scenes/test_level/goal.tscn" id="3_t2q2r"]
@@ -1458,6 +1459,8 @@ sources/0 = SubResource("TileSetAtlasSource_pdjj0")
 
 [node name="TestLevel" type="Node2D"]
 script = ExtResource("1_x5js2")
+
+[node name="CanvasLayer" parent="." instance=ExtResource("2_bmjn4")]
 
 [node name="HUD" type="CanvasLayer" parent="."]
 

--- a/scripts/credits_scene.gd
+++ b/scripts/credits_scene.gd
@@ -2,4 +2,3 @@ extends Control
 
 func _on_button_pressed():
 	visible = false
-	pass # Replace with function body.

--- a/scripts/menu.gd
+++ b/scripts/menu.gd
@@ -16,8 +16,7 @@ func _on_settings_button_pressed():
 
 func _on_credits_button_pressed():
 	print("credits button")
-	var credits = preload("res://scenes/credits_scene.tscn").instantiate()
-	add_sibling(credits)
+	$credits.visible = true
 
 func _on_quit_button_pressed():
 	print('quit button')


### PR DESCRIPTION
Implementerte bakgrunn til test levelet.

Credits skjermen er ikke lenger gjennomsiktig.

Credits skjermen blir nå, istedenfor å bli instanset inn på scenen så har den blitt lagt til scenen, først usynlig, og så blir den gjort synlig når credits knappen har blitt trykket på via denne linjen med kode: $credits.visible = true. 

I script folderen har det blitt lagt til ett script som brukes i credits scenen med en funksjon til en knapp som skal gjøre den usynlig, noe som vil sende spilleren tilbake til meny skjermen. Dette gjøres med denne linjen kode: visible = false. 