### PR TITLE
Byttet om lydfilene fra AudioStreamPlayer2D til AudioStreamPlayer

### DIFF
--- a/assets/art_assets/bakgrunner/bakgrunn_skog/parallax_far.png.import
+++ b/assets/art_assets/bakgrunner/bakgrunn_skog/parallax_far.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://sdxttbvytln5"
-path="res://.godot/imported/parallax_far.png-69a800da320b8ab2498245aadbaa09cf.ctex"
+path="res://.godot/imported/parallax_far.png-1c725d7584385a9a0efc20d30a5d6116.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Textures/world-1 background export/parallax_far.png"
-dest_files=["res://.godot/imported/parallax_far.png-69a800da320b8ab2498245aadbaa09cf.ctex"]
+source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/parallax_far.png"
+dest_files=["res://.godot/imported/parallax_far.png-1c725d7584385a9a0efc20d30a5d6116.ctex"]
 
 [params]
 

--- a/assets/art_assets/bakgrunner/bakgrunn_skog/parallax_middle.png.import
+++ b/assets/art_assets/bakgrunner/bakgrunn_skog/parallax_middle.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dagpn5eu4pjbd"
-path="res://.godot/imported/parallax_middle.png-66cbd86d1576199dfd9bc9422e85781c.ctex"
+path="res://.godot/imported/parallax_middle.png-135c53752e33eb58a95c39c0050f48b1.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Textures/world-1 background export/parallax_middle.png"
-dest_files=["res://.godot/imported/parallax_middle.png-66cbd86d1576199dfd9bc9422e85781c.ctex"]
+source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/parallax_middle.png"
+dest_files=["res://.godot/imported/parallax_middle.png-135c53752e33eb58a95c39c0050f48b1.ctex"]
 
 [params]
 

--- a/assets/art_assets/bakgrunner/bakgrunn_skog/skog_bakgrunn_bakke.png.import
+++ b/assets/art_assets/bakgrunner/bakgrunn_skog/skog_bakgrunn_bakke.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b0d0haqdf28fg"
-path="res://.godot/imported/skog_bakgrunn_bakke.png-0945903f520cf114a1e73bacfea2cbe7.ctex"
+path="res://.godot/imported/skog_bakgrunn_bakke.png-229760559ae1c1382b8f1f5da376a861.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Textures/world-1 background export/skog_bakgrunn_bakke.png"
-dest_files=["res://.godot/imported/skog_bakgrunn_bakke.png-0945903f520cf114a1e73bacfea2cbe7.ctex"]
+source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/skog_bakgrunn_bakke.png"
+dest_files=["res://.godot/imported/skog_bakgrunn_bakke.png-229760559ae1c1382b8f1f5da376a861.ctex"]
 
 [params]
 

--- a/assets/art_assets/bakgrunner/bakgrunn_skog/skog_himmel.jpg.import
+++ b/assets/art_assets/bakgrunner/bakgrunn_skog/skog_himmel.jpg.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://3s1gjx7hhvsi"
-path="res://.godot/imported/skog_himmel.jpg-b2f2ce5dd3ec3965e3c4ea2ea501fb14.ctex"
+path="res://.godot/imported/skog_himmel.jpg-b356d7ee4aa4403fdff944700f02577b.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Textures/world-1 background export/skog_himmel.jpg"
-dest_files=["res://.godot/imported/skog_himmel.jpg-b2f2ce5dd3ec3965e3c4ea2ea501fb14.ctex"]
+source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/skog_himmel.jpg"
+dest_files=["res://.godot/imported/skog_himmel.jpg-b356d7ee4aa4403fdff944700f02577b.ctex"]
 
 [params]
 

--- a/assets/art_assets/texture/dirt_texture.png.import
+++ b/assets/art_assets/texture/dirt_texture.png.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://r17tlf5r7aed"
-path="res://.godot/imported/parallax_front.png-a1c7256b0dff94cedbee235dec54ff45.ctex"
+uid="uid://do6k81b27m6fq"
+path="res://.godot/imported/dirt_texture.png-b78e15e25ef1c656fe6656b2b088810e.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/parallax_front.png"
-dest_files=["res://.godot/imported/parallax_front.png-a1c7256b0dff94cedbee235dec54ff45.ctex"]
+source_file="res://assets/art_assets/texture/dirt_texture.png"
+dest_files=["res://.godot/imported/dirt_texture.png-b78e15e25ef1c656fe6656b2b088810e.ctex"]
 
 [params]
 

--- a/assets/art_assets/texture/grass_texture.png.import
+++ b/assets/art_assets/texture/grass_texture.png.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://r17tlf5r7aed"
-path="res://.godot/imported/parallax_front.png-a1c7256b0dff94cedbee235dec54ff45.ctex"
+uid="uid://cvpdq1ryy0745"
+path="res://.godot/imported/grass_texture.png-7a226328f0bcfc5bc37d396d44648bd4.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/parallax_front.png"
-dest_files=["res://.godot/imported/parallax_front.png-a1c7256b0dff94cedbee235dec54ff45.ctex"]
+source_file="res://assets/art_assets/texture/grass_texture.png"
+dest_files=["res://.godot/imported/grass_texture.png-7a226328f0bcfc5bc37d396d44648bd4.ctex"]
 
 [params]
 

--- a/assets/art_assets/texture/skog_texture.png.import
+++ b/assets/art_assets/texture/skog_texture.png.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://r17tlf5r7aed"
-path="res://.godot/imported/parallax_front.png-a1c7256b0dff94cedbee235dec54ff45.ctex"
+uid="uid://dom04f3at7hlt"
+path="res://.godot/imported/skog_texture.png-a77be2b1b0f90b0d2b779337d734c6cc.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://assets/art_assets/bakgrunner/bakgrunn_skog/parallax_front.png"
-dest_files=["res://.godot/imported/parallax_front.png-a1c7256b0dff94cedbee235dec54ff45.ctex"]
+source_file="res://assets/art_assets/texture/skog_texture.png"
+dest_files=["res://.godot/imported/skog_texture.png-a77be2b1b0f90b0d2b779337d734c6cc.ctex"]
 
 [params]
 


### PR DESCRIPTION
Endret type node lydfilene var lagret som for å fikse opp i en bug der lydene blir lavere å lavere når spilleren beveger seg vekk fra objektet som lager lyd. Lyden høres nå ut som den skal.