### PR TITLE
Fikset problemet med at keyboard kommer opp

### DIFF
--- a/scenes/menus/credits_menu.tscn
+++ b/scenes/menus/credits_menu.tscn
@@ -76,6 +76,10 @@ Music:
 
 SYNTRUS (on newgrounds)"
 editable = false
+context_menu_enabled = false
+drag_and_drop_selection_enabled = false
+virtual_keyboard_enabled = false
+middle_mouse_paste_enabled = false
 
 [node name="Button" type="Button" parent="."]
 layout_mode = 1


### PR DESCRIPTION
Bytt ut den gamle credits menyen med denne

Det var ett problem med at keyboard kommer opp når du trykker på teksten i denne scenen. Jeg er ganske sikker på at jeg har fikset det nå. Jeg har ikke testet det på mobil, men det jeg gjorde var at jeg satte en propery fra textedit noden kalt 'virtual_keyboard_enabled' til false, beskrivelsen for denne sier: "if true, the native virtual keyboard is shown when focused on platforms that support it."

Så ja jeg er ganske sikker på at det fungerer.