### PR TITLE
Fikset kreditterings tekstboks instillinger

### DIFF
--- a/scenes/menus/credits_menu.tscn
+++ b/scenes/menus/credits_menu.tscn
@@ -76,6 +76,10 @@ Music:
 
 SYNTRUS (on newgrounds)"
 editable = false
+context_menu_enabled = false
+shortcut_keys_enabled = false
+virtual_keyboard_enabled = false
+middle_mouse_paste_enabled = false
 
 [node name="Button" type="Button" parent="."]
 layout_mode = 1


### PR DESCRIPTION
Endret på tekstboks instillinger slik at man ikke lenger får tastatur popup på mobil når man trykker på skjermen


fixes #92