### PR TITLE
Dynamisk prosent på pausemenyen

### DIFF
--- a/scenes/menus/pause_menu.tscn
+++ b/scenes/menus/pause_menu.tscn
@@ -164,14 +164,14 @@ flip_v = true
 
 [node name="Label" type="Label" parent="Percent"]
 layout_mode = 0
-offset_left = 959.0
-offset_top = 300.0
-offset_right = 1312.0
-offset_bottom = 383.0
+offset_left = 926.0
+offset_top = 299.0
+offset_right = 1279.0
+offset_bottom = 382.0
 rotation = 0.0147595
 theme = ExtResource("3_igk0i")
 theme_override_font_sizes/font_size = 60
-text = "0% Ferdig"
+text = "100% Ferdig"
 
 [node name="Settings" parent="." instance=ExtResource("3_0tmxy")]
 visible = false

--- a/scripts/ui/pause.gd
+++ b/scripts/ui/pause.gd
@@ -19,7 +19,16 @@ func _on_quit_button_pressed():
 	get_tree().change_scene_to_file("res://scenes/menus/main_menu.tscn")
 
 func _on_game_manager_toggle_game_paused(is_paused):
-	$".".visible = is_paused
+	visible = is_paused
+	update_percent()
 	#$Camera2D.enabled = true
 	#$Camera2D.make_current()
-	pass
+
+func update_percent():
+	var label = get_node("Percent/Label")
+	var goal = get_node("/root/THE-MAP/MAP-TRIGGERS/goal")
+	var player = get_node("/root/THE-MAP/PLAYER/Raskeladden")
+	
+	var percent = round((player.position.x / goal.position.x) * 100)
+	label.text = str(percent) + "% Ferdig"
+	


### PR DESCRIPTION
"% Ferdig" i pausemenyen oppdaterer nå dynamisk ved bruk av spillerns posisjon og "goal-trigger" sin posisjon

fixes #126