### PR TITLE
Gjemmer pauseknapp ved seier #172

### DIFF
--- a/scripts/controllers/goal.gd
+++ b/scripts/controllers/goal.gd
@@ -10,6 +10,7 @@ func _on_area_2d_body_exited(body):
 	# Viser Level Complete label men ikke i riktig posisjon. Må fikses etterhvert
 	# 2 sekunder går og scenen endres til menyen igjen.
 	if body.get_class() == "CharacterBody2D":
+		$"../../HUD/RightContainer/PauseButton".hide() #Hide the pause button from player on win
 		body.velocity.x = 0
 		body.scroll_speed = 0
 		# body.anim_player.play('idle')


### PR DESCRIPTION
Når spiller kommer i mål, gjemmes pause knappen, slik at spiller ikke kan pause og krasje spillet ved seier.